### PR TITLE
Added  unistd.h

### DIFF
--- a/src/memcbench.cc
+++ b/src/memcbench.cc
@@ -8,6 +8,7 @@
 #include <sys/time.h>
 #include <memcached.h>
 #include <string.h>
+#include <unistd.h>
 #include "opt.h"
 
 unsigned long long timediff(struct timeval tv0, struct timeval tv1)


### PR DESCRIPTION
Old version of gcc ( prior to 4.7) accidentally includes unistd.h in some system headers, so after the given changes program ran perfectly on gcc (after 4.7). @yoshinorim 

![usleep](https://cloud.githubusercontent.com/assets/3715173/6925159/2ac67206-d7fb-11e4-82a0-fe04416917e4.png)
